### PR TITLE
Add types to package.json "exports" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dist"
   ],
   "exports": {
+    "types": "./types/index.d.ts",
     "import": "./src/index.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
If Typescript resolves modules via the "exports" field it also expects the types there.

Related to #2 

TS7016: Could not find a declaration file for module _eslint-plugin-react-you-might-not-need-an-effect_. There are types at `/node_modules/eslint-plugin-react-you-might-not-need-an-effect/types/index.d.ts`, but this result could not be resolved when respecting package.json `exports`. The _eslint-plugin-react-you-might-not-need-an-effect_ library may need to update its package.json or typings.
_____
Note that `"types"` needs to come first inside `"exports"`, before "import" or "require".