### PR TITLE
fix: don't bundle dependencies into dist version

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,5 +7,5 @@ build({
   format: "cjs",
   outfile: "./dist/index.cjs",
   platform: "node",
-  external: ["eslint"],
+  external: ["eslint", "eslint-utils", "globals"],
 });


### PR DESCRIPTION
Installing the package will install these deps anyway, so I don't see a reason to bundle them into the CJS code too.

This reduces the size of the size of the uncompressed tarball (and as such, the install size) from 525K to 142K.