### PR TITLE
fix: unsafe access on undefined useState declaration

### DIFF
--- a/src/rules/no-reset-all-state-on-prop-change.js
+++ b/src/rules/no-reset-all-state-on-prop-change.js
@@ -86,7 +86,7 @@ const findPropUsedToResetAllState = (
 
 const isSetStateToInitialValue = (context, setterRef) => {
   const setStateToValue = getCallExpr(setterRef).arguments[0];
-  const stateInitialValue = getUseStateDecl(context, setterRef).init
+  const stateInitialValue = getUseStateDecl(context, setterRef)?.init
     .arguments[0];
 
   // `useState()` (with no args) defaults to `undefined`,


### PR DESCRIPTION
Fixes #55

I'm not sure if optional chaining is the right approach, or if there's issue in `getUseStateDecl` where we never really expect it to return `undefined`.

There are more areas with potentially unsafe access if the jsdoc types are to be trusted, like the line immediately preceding the one from this PR. I'll update this PR or open a new one if you agree.
```diff
- const setStateToValue = getCallExpr(setterRef).arguments[0];
+ const setStateToValue = getCallExpr(setterRef)?.arguments[0];
```