### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "type": "git",
     "url": "https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect.git"
   },
+  "homepage": "https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect#readme",
+  "bugs": {
+    "url": "https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect/issues"
+  },
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsgo",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the README
- add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
