### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "eslint-plugin-react-you-might-not-need-an-effect",
   "version": "1.0.0",
+  "bugs": {
+    "url": "https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect/issues"
+  },
   "description": "ESLint rule to warn against unnecessary React useEffect hooks.",
   "author": "Nick van Dyke",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.